### PR TITLE
Fix transaction rollback when `onFailure` is used

### DIFF
--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -149,6 +149,10 @@ class Pipeline implements PipelineContract
         } catch (Throwable $e) {
             $this->rollbackTransaction();
 
+            if ($this->onFailure) {
+                return ($this->onFailure)($this->passable, $e);
+            }
+
             return $this->handleException($this->passable, $e);
         }
     }
@@ -187,40 +191,32 @@ class Pipeline implements PipelineContract
     {
         return function ($stack, $pipe) {
             return function ($passable) use ($stack, $pipe) {
-                try {
-                    if (is_callable($pipe)) {
-                        // If the pipe is a callable, then we will call it directly, but otherwise we
-                        // will resolve the pipes out of the dependency container and call it with
-                        // the appropriate method and arguments, returning the results back out.
-                        return $pipe($passable, $stack);
-                    } elseif (! is_object($pipe)) {
-                        [$name, $parameters] = $this->parsePipeString($pipe);
+                if (is_callable($pipe)) {
+                    // If the pipe is a callable, then we will call it directly, but otherwise we
+                    // will resolve the pipes out of the dependency container and call it with
+                    // the appropriate method and arguments, returning the results back out.
+                    return $pipe($passable, $stack);
+                } elseif (! is_object($pipe)) {
+                    [$name, $parameters] = $this->parsePipeString($pipe);
 
-                        // If the pipe is a string we will parse the string and resolve the class out
-                        // of the dependency injection container. We can then build a callable and
-                        // execute the pipe function giving in the parameters that are required.
-                        $pipe = $this->getContainer()->make($name);
+                    // If the pipe is a string we will parse the string and resolve the class out
+                    // of the dependency injection container. We can then build a callable and
+                    // execute the pipe function giving in the parameters that are required.
+                    $pipe = $this->getContainer()->make($name);
 
-                        $parameters = array_merge([$passable, $stack], $parameters);
-                    } else {
-                        // If the pipe is already an object we'll just make a callable and pass it to
-                        // the pipe as-is. There is no need to do any extra parsing and formatting
-                        // since the object we're given was already a fully instantiated object.
-                        $parameters = [$passable, $stack];
-                    }
-
-                    $carry = method_exists($pipe, $this->method)
-                                    ? $pipe->{$this->method}(...$parameters)
-                                    : $pipe(...$parameters);
-
-                    return $this->handleCarry($carry);
-                } catch (Throwable $e) {
-                    if ($this->onFailure) {
-                        return ($this->onFailure)($passable, $e, $pipe);
-                    }
-
-                    return $this->handleException($passable, $e);
+                    $parameters = array_merge([$passable, $stack], $parameters);
+                } else {
+                    // If the pipe is already an object we'll just make a callable and pass it to
+                    // the pipe as-is. There is no need to do any extra parsing and formatting
+                    // since the object we're given was already a fully instantiated object.
+                    $parameters = [$passable, $stack];
                 }
+
+                $carry = method_exists($pipe, $this->method)
+                                ? $pipe->{$this->method}(...$parameters)
+                                : $pipe(...$parameters);
+
+                return $this->handleCarry($carry);
             };
         };
     }


### PR DESCRIPTION
## About
- Fixed transaction rollback when `onFailure` is used;
- Dropped support of `pipe` argument;
