### PR TITLE
Make parameters optional in `pipeline` helper

### DIFF
--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -15,11 +15,11 @@ if (! function_exists('pipeline')) {
     {
         $pipeline = app(Pipeline::class);
 
-        if (filled($passable)) {
+        if (! is_null($passable)) {
             $pipeline->send($passable);
         }
 
-        if (filled($pipes)) {
+        if (! is_null($pipes)) {
             $pipeline->through($pipes);
         }
 

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -11,10 +11,18 @@ if (! function_exists('pipeline')) {
      *
      * @return Pipeline
      */
-    function pipeline($passable, $pipes): Pipeline
+    function pipeline($passable = [], $pipes = []): Pipeline
     {
-        return app(Pipeline::class)
-            ->send($passable)
-            ->through($pipes);
+        $pipeline = app(Pipeline::class);
+
+        if (filled($passable)) {
+            $pipeline->send($passable);
+        }
+
+        if (filled($pipes)) {
+            $pipeline->through($pipes);
+        }
+
+        return $pipeline;
     }
 }

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -11,7 +11,7 @@ if (! function_exists('pipeline')) {
      *
      * @return Pipeline
      */
-    function pipeline($passable = [], $pipes = []): Pipeline
+    function pipeline($passable = null, $pipes = null): Pipeline
     {
         $pipeline = app(Pipeline::class);
 

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -154,6 +154,17 @@ class PipelineTest extends TestCase
 
         $this->assertSame('test', $test);
     }
+
+    /** @test */
+    public function testPipelineHelperWithoutParameters()
+    {
+        $test = pipeline()
+            ->send('data')
+            ->through(TestPipe::class)
+            ->thenReturn();
+
+        $this->assertSame('data', $test);
+    }
 }
 
 class PipelineWithException


### PR DESCRIPTION
## About
Since `v2.1.0` it was required to pass a `passable` and `pipes` parameters to the pipeline helper. They're now optional.

```php
pipeline()
  ->send($data)
  ->through(Pipe::class)
  ->thenReturn();
```