### PR TITLE
Add `run` helper

### DIFF
--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -26,3 +26,18 @@ if (! function_exists('pipeline')) {
         return $pipeline;
     }
 }
+
+if (! function_exists('run')) {
+    /**
+     * @param  string  $action
+     * @param  mixed  $data
+     * @return mixed
+     */
+    function run(string $action, mixed $data = true): mixed
+    {
+        return app(Pipeline::class)
+            ->send($data)
+            ->through([$action])
+            ->thenReturn();
+    }
+}

--- a/tests/PipelineRunHelperTest.php
+++ b/tests/PipelineRunHelperTest.php
@@ -15,7 +15,9 @@ class PipelineRunHelperTest extends TestCase
 
     public function testRunHelperActionReturnsPassedData()
     {
-        $executed = run(Action::class, ['test' => 'yeah']);
+        $data = ['test' => 'yeah'];
+
+        $executed = run(Action::class, with($data));
 
         $this->assertSame('yeah', $executed['test']);
     }

--- a/tests/PipelineRunHelperTest.php
+++ b/tests/PipelineRunHelperTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace MichaelRubel\EnhancedPipeline\Tests;
+
+use MichaelRubel\EnhancedPipeline\Pipeline;
+
+class PipelineRunHelperTest extends TestCase
+{
+    public function testRunHelperWithoutParams()
+    {
+        $executed = run(Action::class);
+
+        $this->assertTrue($executed);
+    }
+
+    public function testRunHelperActionReturnsPassedData()
+    {
+        $executed = run(Action::class, ['test' => 'yeah']);
+
+        $this->assertSame('yeah', $executed['test']);
+    }
+
+    public function testRunHelperHasCustomizableMethod()
+    {
+        $this->app->resolving(Pipeline::class, function ($pipeline) {
+            return $pipeline->via('execute');
+        });
+
+        $executed = run(ActionExecute::class);
+
+        $this->assertTrue($executed);
+    }
+}
+
+class Action
+{
+    public function handle(mixed $data, \Closure $next): mixed
+    {
+        return $next($data);
+    }
+}
+
+class ActionExecute
+{
+    public function execute(mixed $data, \Closure $next): mixed
+    {
+        return $next($data);
+    }
+}


### PR DESCRIPTION
## About
This is the convenient way to run a single action that is pipeline-compatible.

Instead of:
```php
pipeline($data, MyAction::class)
  ->thenReturn();
```

You would use:
```php
run(MyAction::class, $data);
```

By default, it uses `handle` method in your action classes, but you can customize it by adding code to your ServiceProvider:
```php
$this->app->resolving(Pipeline::class, function ($pipeline) {
    return $pipeline->via('execute');
});
```

With this configuration, the pipeline in `run` helper will use the `execute` underlying method.

---