### PR TITLE
Drop Laravel 8 and support PHP `8.2` 🐘

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,14 +13,9 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 8.1]
-        laravel: [^8.71, 9.*]
+        php: [8.0, 8.1, 8.2]
+        laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
-        include:
-          - testbench: 7.*
-            laravel: 9.*
-          - testbench: ^6.6
-            laravel: ^8.71
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -42,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.62.1" --dev --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
         "brianium/paratest": "^6.3",
         "laravel/pint": "^0.2.1",
         "mockery/mockery": "^1.4.4",
-        "nunomaduro/collision": "^5.10|^6.0",
+        "nunomaduro/collision": "^6.0",
         "nunomaduro/larastan": "^1.0",
-        "orchestra/testbench": "^6.6|^7.0",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.5",
-        "roave/backward-compatibility-check": "^6.4|^7.0"
+        "roave/backward-compatibility-check": "^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## About

This PR drops support of Laravel 8 and ensures the package works with PHP 8.2.

---